### PR TITLE
fix, tests

### DIFF
--- a/src/backers.ts
+++ b/src/backers.ts
@@ -14,15 +14,21 @@ export function getCollectiveBackerTiers(
   allBackers: Member[],
   backerName: string,
   backerOrganisations: string[],
-): Tier[] {
-  const tiers = allBackers.reduce<Tier[]>((acc, member) => {
-    if (!member.github) return acc
+): Tier[] | null {
+  const tiers = allBackers.reduce<Tier[] | null>((acc, member) => {
+    if (!member.github || acc === null) return acc
 
     const githubName = stripGithubName(member.github)
     const isMember = [...backerOrganisations, backerName].some(is(githubName))
 
+    /* Tiers */
     if (isMember && member.role === 'BACKER' && member.tier) {
       return uniq([...acc, member.tier])
+    }
+
+    /* Admins, Contributors */
+    if (isMember && ['HOST', 'ADMIN', 'CONTRIBUTOR'].includes(member.role)) {
+      return null
     }
 
     return acc

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -46,6 +46,13 @@ export const opencollective = (app: probot.Application): void => {
       backerOrganisations,
     )
 
+    /**
+     * Ignore messages to admins, contributors...
+     */
+    if (backerTiers === null) {
+      return
+    }
+
     // Calculate messages and labels
     const dict = {
       '<author>': backerName,
@@ -91,6 +98,13 @@ export const opencollective = (app: probot.Application): void => {
       backerName,
       backerOrganisations,
     )
+
+    /**
+     * Admins, Contributors,... have full control over labels.
+     */
+    if (backerTiers === null) {
+      return
+    }
 
     // Calculate messages and labels
     const allLabels = getLabelsFromConfig(config)

--- a/tests/__fixtures__/backers.ts
+++ b/tests/__fixtures__/backers.ts
@@ -498,4 +498,12 @@ export const backers: Member[] = [
     name: 'Airbnb',
     github: 'https://github.com/airbnb',
   },
+  {
+    MemberId: 1770,
+    type: 'USER',
+    role: 'ADMIN',
+    isActive: true,
+    name: 'Open Source Collective 501c6 (Non Profit)',
+    github: 'https://github.com/maticzav',
+  },
 ]

--- a/tests/backers.test.ts
+++ b/tests/backers.test.ts
@@ -11,4 +11,12 @@ describe('backers', () => {
 
     expect(res).toEqual(['Backer', 'Sponsor'])
   })
+  test('backers return null on admin role', async () => {
+    const res = await getCollectiveBackerTiers(backers, 'maticzav', [
+      'airbnb',
+      'something-else',
+    ])
+
+    expect(res).toEqual(null)
+  })
 })

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -91,7 +91,112 @@ describe('opencollective issues.opened', () => {
     expect(github.issues.removeLabel).toBeCalledTimes(0)
   })
 
-  test('works correctly', async () => {
+  test('ignores admin issues', async () => {
+    nock('https://opencollective.com/')
+      .get('/graphql-shield/members.json')
+      .reply(200, [
+        {
+          MemberId: 1,
+          type: 'USER',
+          role: 'ADMIN',
+          tier: 'Backer',
+          isActive: true,
+          name: 'maticzav',
+          github: 'https://github.com/maticzav',
+        },
+        {
+          MemberId: 2,
+          type: 'ORGANIZATION',
+          role: 'BACKER',
+          tier: 'Sponsor',
+          isActive: true,
+          name: 'graphql-boilerplates',
+          github: 'https://github.com/graphql-boilerplates',
+        },
+      ] as Member[])
+
+    const app = new probot.Application()
+
+    const github = {
+      integrations: {
+        getInstallations: jest.fn(),
+      },
+      paginate: jest.fn(),
+      issues: {
+        createComment: jest
+          .fn()
+          .mockImplementation(args => Promise.resolve(args)),
+        getLabel: jest.fn().mockImplementation(() =>
+          Promise.reject({
+            code: 404,
+            status: 'Not Found',
+            headers: {},
+          }),
+        ),
+        createLabel: jest
+          .fn()
+          .mockImplementation(args => Promise.resolve(args)),
+        addLabels: jest.fn().mockImplementation(args => Promise.resolve(args)),
+        removeLabel: jest
+          .fn()
+          .mockImplementation(args => Promise.resolve(args)),
+      },
+      repos: {
+        getContents: jest.fn().mockReturnValue({
+          data: {
+            content: config,
+          },
+        }),
+      },
+      orgs: {
+        listForUser: jest.fn().mockResolvedValue({
+          status: 200,
+          data: [
+            {
+              login: 'graphql-boilerplates',
+              id: 18574799,
+              node_id: 'MDEyOk9yZ2FuaXphdGlvbjE4NTc0Nzk5',
+              url: 'https://api.github.com/orgs/graphql-boilerplates',
+              repos_url:
+                'https://api.github.com/orgs/graphql-boilerplates/repos',
+              events_url:
+                'https://api.github.com/orgs/graphql-boilerplates/events',
+              hooks_url:
+                'https://api.github.com/orgs/graphql-boilerplates/hooks',
+              issues_url:
+                'https://api.github.com/orgs/graphql-boilerplates/issues',
+              members_url:
+                'https://api.github.com/orgs/graphql-boilerplates/members{/member}',
+              public_members_url:
+                'https://api.github.com/orgs/graphql-boilerplates/public_members{/member}',
+              avatar_url:
+                'https://avatars2.githubusercontent.com/u/18574799?v=4',
+              description:
+                'Collection of production-ready GraphQL boilerplate projects',
+            },
+          ],
+          headers: {},
+        }),
+      },
+    }
+
+    app.load(opencollective)
+    app.auth = () => Promise.resolve(github as any)
+
+    await app.receive({
+      name: 'issues',
+      payload: issueOpenedFixture,
+    })
+
+    expect(github.repos.getContents).toBeCalledTimes(1)
+    expect(github.issues.createComment).toBeCalledTimes(0)
+    expect(github.issues.getLabel).toBeCalledTimes(0)
+    expect(github.issues.createLabel).toBeCalledTimes(0)
+    expect(github.issues.addLabels).toBeCalledTimes(0)
+    expect(github.issues.removeLabel).toBeCalledTimes(0)
+  })
+
+  test('sends correct message', async () => {
     nock('https://opencollective.com/')
       .get('/graphql-shield/members.json')
       .reply(200, [
@@ -327,6 +432,110 @@ describe('opencollective issues.labeled', () => {
           type: 'USER',
           role: 'BACKER',
           tier: 'Backer',
+          isActive: true,
+          name: 'maticzav',
+          github: 'https://github.com/maticzav',
+        },
+        {
+          MemberId: 2,
+          type: 'ORGANIZATION',
+          role: 'BACKER',
+          tier: 'Sponsor',
+          isActive: true,
+          name: 'graphql-boilerplates',
+          github: 'https://github.com/graphql-boilerplates',
+        },
+      ] as Member[])
+
+    const app = new probot.Application()
+
+    const github = {
+      integrations: {
+        getInstallations: jest.fn(),
+      },
+      paginate: jest.fn(),
+      issues: {
+        createComment: jest
+          .fn()
+          .mockImplementation(args => Promise.resolve(args)),
+        getLabel: jest.fn().mockImplementation(() =>
+          Promise.reject({
+            code: 404,
+            status: 'Not Found',
+            headers: {},
+          }),
+        ),
+        createLabel: jest
+          .fn()
+          .mockImplementation(args => Promise.resolve(args)),
+        addLabels: jest.fn().mockImplementation(args => Promise.resolve(args)),
+        removeLabel: jest
+          .fn()
+          .mockImplementation(args => Promise.resolve(args)),
+      },
+      repos: {
+        getContents: jest.fn().mockReturnValue({
+          data: {
+            content: config,
+          },
+        }),
+      },
+      orgs: {
+        listForUser: jest.fn().mockResolvedValue({
+          status: 200,
+          data: [
+            {
+              login: 'graphql-boilerplates',
+              id: 18574799,
+              node_id: 'MDEyOk9yZ2FuaXphdGlvbjE4NTc0Nzk5',
+              url: 'https://api.github.com/orgs/graphql-boilerplates',
+              repos_url:
+                'https://api.github.com/orgs/graphql-boilerplates/repos',
+              events_url:
+                'https://api.github.com/orgs/graphql-boilerplates/events',
+              hooks_url:
+                'https://api.github.com/orgs/graphql-boilerplates/hooks',
+              issues_url:
+                'https://api.github.com/orgs/graphql-boilerplates/issues',
+              members_url:
+                'https://api.github.com/orgs/graphql-boilerplates/members{/member}',
+              public_members_url:
+                'https://api.github.com/orgs/graphql-boilerplates/public_members{/member}',
+              avatar_url:
+                'https://avatars2.githubusercontent.com/u/18574799?v=4',
+              description:
+                'Collection of production-ready GraphQL boilerplate projects',
+            },
+          ],
+          headers: {},
+        }),
+      },
+    }
+
+    app.load(opencollective)
+    app.auth = () => Promise.resolve(github as any)
+
+    await app.receive({
+      name: 'issues',
+      payload: issueLabeledFixture,
+    })
+
+    expect(github.repos.getContents).toBeCalledTimes(1)
+    expect(github.issues.createComment).toBeCalledTimes(0)
+    expect(github.issues.getLabel).toBeCalledTimes(0)
+    expect(github.issues.createLabel).toBeCalledTimes(0)
+    expect(github.issues.addLabels).toBeCalledTimes(0)
+    expect(github.issues.removeLabel).toBeCalledTimes(0)
+  })
+
+  test('ignores admin label', async () => {
+    nock('https://opencollective.com/')
+      .get('/graphql-shield/members.json')
+      .reply(200, [
+        {
+          MemberId: 1,
+          type: 'USER',
+          role: 'ADMIN',
           isActive: true,
           name: 'maticzav',
           github: 'https://github.com/maticzav',

--- a/tests/collective.test.ts
+++ b/tests/collective.test.ts
@@ -35,22 +35,26 @@ const memberTypeSchema = joi.object().keys({
 })
 
 describe('collective', () => {
-  test('get members has expected types', async () => {
-    const res = await getCollectiveMembers('webpack')
-    expect(res.length).not.toBe(0)
-    const validations = res.map(async member => {
-      try {
-        await joi.validate(member, memberTypeSchema, { allowUnknown: true })
-      } catch (err) {
-        console.log(err, member)
-        throw err
-      }
-    })
+  test(
+    'get members has expected types',
+    async () => {
+      const res = await getCollectiveMembers('webpack')
+      expect(res.length).not.toBe(0)
+      const validations = res.map(async member => {
+        try {
+          await joi.validate(member, memberTypeSchema, { allowUnknown: true })
+        } catch (err) {
+          console.log(err, member)
+          throw err
+        }
+      })
 
-    try {
-      await Promise.all(validations)
-    } catch (err) {
-      fail(err)
-    }
-  })
+      try {
+        await Promise.all(validations)
+      } catch (err) {
+        fail(err)
+      }
+    },
+    60 * 1000,
+  )
 })


### PR DESCRIPTION
@znarf this fixes #49. It was an honest mistake that I forgot about during development. It should be good to go.

The only thing I wanted to do is discuss upfront on how to tackle this in a better manner, but this works as well. I am not very fond of edge cases with many `if` statements because they often lead to problems in upcoming versions.

With this PR admins will no longer receive messages when they open issues or have their labels removed when they set them in an issue regardless of the configuration.