### PR TITLE
fix: downgrade now runtime

### DIFF
--- a/now.json
+++ b/now.json
@@ -3,7 +3,7 @@
   "name": "opencollective-bot",
   "version": 2,
   "alias": "bot.opencollective.com",
-  "builds": [{ "src": "src/index.ts", "use": "@now/node-server@canary" }],
+  "builds": [{ "src": "src/index.ts", "use": "@now/node-server@0.7.4" }],
   "routes": [{ "src": "/.*", "dest": "src/index.ts" }],
   "env": {
     "APP_ID": "@oc-bot-app-id",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/node": "11.13.17",
     "@types/node-fetch": "2.3.7",
     "@types/request-promise-native": "1.0.16",
-    "@zeit/ncc": "0.20.4",
+    "@zeit/ncc": "0.18.5",
     "btoa": "1.2.1",
     "codecov": "3.5.0",
     "dotenv-cli": "2.0.0",


### PR DESCRIPTION
The Bot is currently broken in production.

A `@zeit/ncc` `@zeit/node-server` release might have triggering that.

https://github.com/zeit/now-builders/commit/cd45dce724405968e9e6f58ae4fad983c5d35f20