### PR TITLE
Simpler webhook proxy setup

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -10,10 +10,6 @@
 
 - `npm install --global yarn`
 
-3. Make sure you have the [smee.io](https://smee.io/) client available:
-
-- `npm install --global smee-client`
-
 ## Install
 
 We recommend cloning the repository in a folder dedicated to `opencollective` projects.
@@ -63,24 +59,13 @@ Create in the project directory an `.env` file with the following content:
 APP_ID=<APP_ID>
 WEBHOOK_SECRET=development
 PRIVATE_KEY_PATH=private-key.pem
+WEBHOOK_PROXY_URL=<WEBHOOK_PROXY_URL>
 ```
 
 ## Start
-
-### Start the app
 
 In a terminal, run:
 
 ```
 yarn dev
 ```
-
-### Start the Webhook proxy
-
-In a separated terminal, using the `WEBHOOK_PROXY_URL` created before, run:
-
-```
-smee -u <WEBHOOK_PROXY_URL>
-```
-
-example: `smee -u https://smee.io/O1MG7MFNgng8gPJx`

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "request": "2.88.0",
     "request-promise-native": "1.0.7",
     "rimraf": "2.6.3",
+    "smee-client": "1.1.0",
     "ts-jest": "24.0.2",
     "ts-node": "8.3.0",
     "typescript": "3.5.2"

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -16,7 +16,7 @@ import {
 import { is, not } from './utils'
 
 export const opencollective = (app: probot.Application): void => {
-  app.log('OpenCollective Bot up!')
+  app.log('Open Collective Bot up!')
 
   app.on('issues.opened', async (context: probot.Context) => {
     const issue = context.issue()

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,17 @@ import { Server } from 'http'
 import { createProbot, ApplicationFunction } from 'probot'
 import { findPrivateKey } from 'probot/lib/private-key'
 import { logRequestErrors } from 'probot/lib/middleware/log-request-errors'
+import { createWebhookProxy } from 'probot/lib/webhook-proxy'
 
 import { opencollective } from './bot'
 import { validator } from './validate'
 
+const port = Number(process.env.PORT) || 3000
+
 /* istanbul ignore if */
 if (process.env.NODE_ENV !== 'test') {
   try {
-    main(3000)
-    console.log(`Server UP! 🚀`)
+    main(port)
   } catch (err) {
     console.log(err)
   }
@@ -59,6 +61,17 @@ export function main(port: number): Server {
 
   // Register error handler as the last middleware
   probot.server.use(logRequestErrors as any)
+
+  /* Load Webhook Proxy */
+
+  if (process.env.WEBHOOK_PROXY_URL) {
+    createWebhookProxy({
+      logger: probot.logger,
+      port,
+      path: '/',
+      url: process.env.WEBHOOK_PROXY_URL,
+    })
+  }
 
   /* Start the server */
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -13,6 +13,7 @@ describe('index', () => {
     delete process.env.PRIVATE_KEY
     delete process.env.PRIVATE_KEY_PATH
     delete process.env.DISABLE_STATS
+    delete process.env.WEBHOOK_PROXY_URL
   })
 
   test('reports missing credentials', () => {
@@ -47,6 +48,25 @@ describe('index', () => {
       './__fixtures__/cert.pem',
     )
     process.env.DISABLE_STATS = 'true'
+
+    try {
+      const server = main(0)
+
+      server.close()
+    } catch (err) {
+      fail(err)
+    }
+  })
+
+  test('correctly build server with webhook url', () => {
+    process.env.APP_ID = '1234'
+    process.env.WEBHOOK_SECRET = 'secret'
+    process.env.PRIVATE_KEY_PATH = path.resolve(
+      __dirname,
+      './__fixtures__/cert.pem',
+    )
+    process.env.DISABLE_STATS = 'true'
+    process.env.WEBHOOK_PROXY_URL = 'https://smee.io/oZmMHV0di2DWLopN'
 
     try {
       const server = main(0)


### PR DESCRIPTION
Use `createWebhookProxy` from `probot`.

No need to run a separated `smee` anymore.
