### PR TITLE
Update @now/node-server to version 0.8.2

### DIFF
--- a/now.json
+++ b/now.json
@@ -3,7 +3,7 @@
   "name": "opencollective-bot",
   "version": 2,
   "alias": "bot.opencollective.com",
-  "builds": [{ "src": "src/index.ts", "use": "@now/node-server@0.7.4" }],
+  "builds": [{ "src": "src/index.ts", "use": "@now/node-server@0.8.2" }],
   "routes": [{ "src": "/.*", "dest": "src/index.ts" }],
   "env": {
     "APP_ID": "@oc-bot-app-id",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "probot": "9.2.20"
   },
   "devDependencies": {
-    "@now/node-server": "0.7.4",
+    "@now/node-server": "0.8.2",
     "@types/body-parser": "1.17.0",
     "@types/btoa": "1.2.3",
     "@types/express": "4.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,17 +322,17 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@now/node-bridge@^1.1.4":
+"@now/node-bridge@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@now/node-bridge/-/node-bridge-1.2.2.tgz#b4740d8806227b8dd1d4d8481e21b3b30ad299b4"
   integrity sha512-E5xqal3QRN8RvcQ4Q82vtg/hvWmQWaIYp2bJHd550Ps/kemGabcwAAQsP/TUM/4b5oYlOmjrfuYPq9AhMvFqkQ==
 
-"@now/node-server@0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@now/node-server/-/node-server-0.7.4.tgz#b7245c69d0a633a3c0b8c4b8a27a57a65421150e"
-  integrity sha512-EH+v3vgg2nMcYNTImfyYXx6hnJdjeN7kkwQsJHn36BtsnR6YGMBaNKWZwSza91287ugtP+R265B+swwacxnD9Q==
+"@now/node-server@0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@now/node-server/-/node-server-0.8.2.tgz#7d90ed9cc468be601cf00c44006bceb0059d8bc2"
+  integrity sha512-zoDpP2MbXB3aTIjd7RskME+rsUwB1Ao/+YumOGZnsnGFOYXCXDUG20BbO1HhVtbnqBE/OnWoM/QLGGFAHv6PBA==
   dependencies:
-    "@now/node-bridge" "^1.1.4"
+    "@now/node-bridge" "1.2.2"
     "@zeit/ncc" "0.18.5"
     fs-extra "7.0.1"
 


### PR DESCRIPTION
The deployment is actually failing.

`Error: Cannot find module 'hbs'`

Would be great to have a way to detect the error automatically (not reported by CircleCI or now).

Not a surprise, this already happened and was fixed in: https://github.com/opencollective/opencollective-bot/pull/152

The related change in @now/node-server was: https://github.com/zeit/now-builders/commit/cd45dce724405968e9e6f58ae4fad983c5d35f20

So, the problematic change might be between `ncc` `0.18.6` and `0.20.3`.

`@now/node-server` is deprecated anyway and we should try with `@now/node`.

But even in `@now/node`, the server support is already labeled as legacy so we better move to a real serverful deployment (heroku). See: https://zeit.co/docs/runtimes#advanced-usage/advanced-node-js-usage/legacy-serverful-behavior
