### PR TITLE
@hapi/joi and @types/hapi__joi upgraded to 16.1.7 and 16.0.3 respecti…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": "10.x"
   },
   "dependencies": {
-    "@hapi/joi": "15.1.1",
+    "@hapi/joi": "16.1.7",
     "body-parser": "1.19.0",
     "js-yaml": "3.13.1",
     "lodash": "4.17.15",
@@ -27,7 +27,7 @@
     "@types/body-parser": "1.17.1",
     "@types/btoa": "1.2.3",
     "@types/express": "4.17.2",
-    "@types/hapi__joi": "15.0.4",
+    "@types/hapi__joi": "16.0.3",
     "@types/jest": "24.0.22",
     "@types/js-yaml": "3.12.1",
     "@types/lodash": "4.14.145",

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,26 +35,23 @@ const tierConfigSchema = joi.object().keys({
   message: joi.string().required(),
 })
 
-export const configSchema = joi
-  .object()
-  .keys({
-    collective: joi
-      .string()
-      .regex(/^[\w\-]+$/, 'Use your collective slug.')
-      .required(),
-    tiers: joi
-      .array()
-      .items(tierConfigSchema)
-      .optional()
-      .default(defaultConfig.tiers),
-    invitation: joi
-      .string()
-      .default(defaultConfig.invitation)
-      .allow(false)
-      .optional()
-      .description('An invitation message shown to non-backers'),
-  })
-  .requiredKeys(['collective'])
+export const configSchema = joi.object().keys({
+  collective: joi
+    .string()
+    .regex(/^[\w\-]+$/, 'Use your collective slug.')
+    .required(),
+  tiers: joi
+    .array()
+    .items(tierConfigSchema)
+    .optional()
+    .default(defaultConfig.tiers),
+  invitation: joi
+    .string()
+    .default(defaultConfig.invitation)
+    .allow(false)
+    .optional()
+    .description('An invitation message shown to non-backers'),
+})
 
 /**
  *
@@ -67,7 +64,7 @@ export async function getConfig(
 ): Promise<Config | null> {
   try {
     const config = await context.config('opencollective.yml')
-    const value = await joi.validate(config, configSchema)
+    const value = await configSchema.validateAsync(config)
 
     return value
   } catch (err) {

--- a/tests/collective.test.ts
+++ b/tests/collective.test.ts
@@ -41,7 +41,7 @@ describe('collective', () => {
       expect(res.length).not.toBe(0)
       const validations = res.map(async member => {
         try {
-          await joi.validate(member, memberTypeSchema, { allowUnknown: true })
+          await memberTypeSchema.validateAsync(member, { allowUnknown: true })
         } catch (err) {
           console.log(err, member)
           throw err

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -23,7 +23,7 @@ describe('github', () => {
       expect(res.length).not.toBe(0)
       const validations = res.map(async org => {
         try {
-          await joi.validate(org, organsisationTypeSchema, {
+          await organsisationTypeSchema.validateAsync(org, {
             allowUnknown: true,
           })
         } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,37 +139,43 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@hapi/address@2.x.x":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
-  integrity sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==
+"@hapi/address@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.2.tgz#1c794cd6dbf2354d1eb1ef10e0303f573e1c7222"
+  integrity sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==
 
-"@hapi/bourne@1.x.x":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
-  integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
+"@hapi/formula@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-1.2.0.tgz#994649c7fea1a90b91a0a1e6d983523f680e10cd"
+  integrity sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==
 
-"@hapi/hoek@8.x.x":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.1.0.tgz#8f7627b23ed9bf67088fc7f9669e48c63ad421bd"
-  integrity sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA==
+"@hapi/hoek@^8.2.4", "@hapi/hoek@^8.3.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.0.tgz#2f9ce301c8898e1c3248b0a8564696b24d1a9a5a"
+  integrity sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==
 
-"@hapi/joi@15.1.1":
-  version "15.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.1.tgz#c675b8a71296f02833f8d6d243b34c57b8ce19d7"
-  integrity sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==
+"@hapi/joi@16.1.7":
+  version "16.1.7"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-16.1.7.tgz#360857223a87bb1f5f67691537964c1b4908ed93"
+  integrity sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==
   dependencies:
-    "@hapi/address" "2.x.x"
-    "@hapi/bourne" "1.x.x"
-    "@hapi/hoek" "8.x.x"
-    "@hapi/topo" "3.x.x"
+    "@hapi/address" "^2.1.2"
+    "@hapi/formula" "^1.2.0"
+    "@hapi/hoek" "^8.2.4"
+    "@hapi/pinpoint" "^1.0.2"
+    "@hapi/topo" "^3.1.3"
 
-"@hapi/topo@3.x.x":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.2.tgz#57cc1317be1a8c5f47c124f9b0e3c49cd78424d2"
-  integrity sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==
+"@hapi/pinpoint@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-1.0.2.tgz#025b7a36dbbf4d35bf1acd071c26b20ef41e0d13"
+  integrity sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==
+
+"@hapi/topo@^3.1.3":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29"
+  integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
   dependencies:
-    "@hapi/hoek" "8.x.x"
+    "@hapi/hoek" "^8.3.0"
 
 "@jest/console@^24.7.1":
   version "24.7.1"
@@ -529,19 +535,10 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
-"@types/hapi__joi@*":
-  version "15.0.3"
-  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-15.0.3.tgz#eeeca99e3829636975bf39532d6e8279409c78f2"
-  integrity sha512-kncvQstpAQSjQ+J+tL2oYerjOEepv+yJHKM/JD/NmFZyDcy3rYOBcMJhdHRDjBxuSZu3ipGECszhgtmug9VSuw==
-  dependencies:
-    "@types/hapi__joi" "*"
-
-"@types/hapi__joi@15.0.4":
-  version "15.0.4"
-  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-15.0.4.tgz#49e2e1e6da15ade0fdd6db4daf94aecb07bb391b"
-  integrity sha512-VSS6zc7AIOdHVXmqKaGNPYl8eGrMvWi0R5pt3evJL3UdxO8XS28/XAkBXNyLQoymHxhMd4bF3o1U9mZkWDeN8w==
-  dependencies:
-    "@types/hapi__joi" "*"
+"@types/hapi__joi@16.0.3":
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-16.0.3.tgz#8ed6a0bd3a3fc40c0b5ff41b399004c5f9bb0b0b"
+  integrity sha512-gPxCfPcdZx9220GP4MFlhyBonQuyy8c/NZkGJkdtGipaExFzNLGYzkH2eG+yo0eEoVWdSC/JxhokSR/IHfap8Q==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"


### PR DESCRIPTION
All tests were passed.

In **src/config.ts** file, line **57** _.requiredKeys(['collective'])_ had been used for making only collective required. However in line **44** there is already required() statement. So I thought, line **57** is redundant. 

Also, in version 16, **requiredKeys** has been deprecated. Instead of this method, **any.fork()** might be used. 

`.fork(['collective'], (schema) => schema.required())`

