### PR TITLE
Add "funding" to package.json while onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@hapi/joi": "16.1.7",
     "body-parser": "1.19.0",
-    "detect-indent": "^6.0.0",
+    "detect-indent": "6.0.0",
     "js-yaml": "3.13.1",
     "lodash": "4.17.15",
     "multilines": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@hapi/joi": "16.1.7",
     "body-parser": "1.19.0",
+    "detect-indent": "^6.0.0",
     "js-yaml": "3.13.1",
     "lodash": "4.17.15",
     "multilines": "1.0.2",

--- a/src/actions/addPackageJsonFunding.ts
+++ b/src/actions/addPackageJsonFunding.ts
@@ -6,7 +6,7 @@ import { base64 } from '../utils'
 import { getCollectiveWithGithubHandle } from '../collective'
 import { resetBranch } from '../github'
 
-import defaultFundingPackageAsString from '../assets/default-funding-package'
+const defaultFundingPackageAsString = `https://opencollective.com/<YOUR-COLLECTIVE-SLUG>`
 
 const BRANCH_NAME = `opencollective-bot/funding_package`
 

--- a/src/actions/addPackageJsonFunding.ts
+++ b/src/actions/addPackageJsonFunding.ts
@@ -23,6 +23,14 @@ const PR_BODY = mls`
 
 const FUNDING_DEFAULT_FILE_CONTENT = defaultFundingPackageAsString
 
+/**
+ * Finds last line before closing curly bracket of package.json
+ * Adds comma
+ * Adds newContent (new properties to package.json)
+ * Add closing curly bracket
+ * @param packageJSON
+ * @param newContent
+ */
 function updatePackageJson(packageJSON: String, newContent: String) {
   const removeLastChar = packageJSON.substr(0, packageJSON.lastIndexOf('}'))
   const indexes = [
@@ -60,10 +68,14 @@ export default async function addPackageJsonFunding(
     console.log(`There is not package.json on ${owner}/${repo}`)
     return
   }
+
+  // Content Base64 Decoding
   const packageJsonContent = Buffer.from(
     packageJsonFile.content,
     'base64',
   ).toString()
+
+  // Check if package.json already contains funding property
   if (packageJsonContent.includes('"funding":')) {
     console.log(`Funding property already exists on ${owner}/${repo}`)
     return
@@ -87,6 +99,7 @@ export default async function addPackageJsonFunding(
 
   await resetBranch(github, owner, repo, BRANCH_NAME, defaultBranchName)
 
+  // Add funding property to at the end of package.json that fetched from reposiory
   const updatedPackageJsonContent = updatePackageJson(
     packageJsonContent,
     fileContent,

--- a/src/actions/addPackageJsonFunding.ts
+++ b/src/actions/addPackageJsonFunding.ts
@@ -1,0 +1,119 @@
+import mls from 'multilines'
+import Octokit, { ReposGetResponse } from '@octokit/rest'
+
+import { base64 } from '../utils'
+import { getCollectiveWithGithubHandle } from '../collective'
+import { resetBranch } from '../github'
+
+import defaultFundingPackageAsString from '../assets/default-funding-package'
+
+const BRANCH_NAME = `opencollective-bot/funding_package`
+
+const FILE_PATH = 'package.json'
+
+const PR_TITLE = 'Add FUNDING to package.json'
+
+const PR_BODY = mls`
+  | Add FUNDING to package.json
+  |
+  | Add FUNDING to package.json
+  |
+  | Add FUNDING to package.json
+  `
+
+const FUNDING_DEFAULT_FILE_CONTENT = defaultFundingPackageAsString
+
+function updatePackageJson(packageJSON: String, newContent: String) {
+  const removeLastChar = packageJSON.substr(0, packageJSON.lastIndexOf('}'))
+  const indexes = [
+    removeLastChar.lastIndexOf('"'),
+    removeLastChar.lastIndexOf(']'),
+    removeLastChar.lastIndexOf('}'),
+  ]
+  const index = Math.max(...indexes)
+  return (
+    removeLastChar.substr(0, index + 1) +
+    `,
+  ${newContent}
+}`
+  )
+}
+
+export default async function addPackageJsonFunding(
+  github: Octokit,
+  repoResponse: ReposGetResponse,
+) {
+  const owner = repoResponse.owner.login
+  const repo = repoResponse.name
+
+  // Check if package.json file is existing
+  const packageJsonFile = await github.repos
+    .getContents({
+      owner,
+      repo,
+      path: 'package.json',
+    })
+    .then((res: any) => res.data)
+    .catch(() => null)
+
+  if (!packageJsonFile) {
+    console.log(`There is not package.json on ${owner}/${repo}`)
+    return
+  }
+  const packageJsonContent = Buffer.from(
+    packageJsonFile.content,
+    'base64',
+  ).toString()
+  if (packageJsonContent.includes('"funding":')) {
+    console.log(`Funding property already exists on ${owner}/${repo}`)
+    return
+  }
+
+  let fileContent = FUNDING_DEFAULT_FILE_CONTENT
+
+  // Fetch the collective from Open Collective
+  const collective = await getCollectiveWithGithubHandle(`${owner}/${repo}`)
+
+  // Replace placeholder with proper collective slug
+  if (collective) {
+    fileContent = fileContent.replace('<YOUR-COLLECTIVE-SLUG>', collective.slug)
+  }
+
+  // Get information about the repo
+  // we're only interested in the default_branch
+  const { default_branch: defaultBranchName } = await github.repos
+    .get({ owner, repo })
+    .then((res: any) => res.data)
+
+  await resetBranch(github, owner, repo, BRANCH_NAME, defaultBranchName)
+
+  const updatedPackageJsonContent = updatePackageJson(
+    packageJsonContent,
+    fileContent,
+  )
+  // Update Package.json
+  await github.repos.createOrUpdateFile({
+    owner,
+    repo,
+    path: FILE_PATH,
+    message: `Funding added to ${FILE_PATH}`,
+    content: base64(updatedPackageJsonContent),
+    sha: packageJsonFile.sha,
+    branch: BRANCH_NAME,
+  })
+
+  // Create the PR
+  const pr = await github.pulls
+    .create({
+      owner,
+      repo,
+      head: BRANCH_NAME,
+      base: defaultBranchName,
+      title: PR_TITLE,
+      body: PR_BODY,
+      maintainer_can_modify: true,
+    })
+    .then((res: any) => res.data)
+
+  console.log(`PR created for adding fund property to package.json: ${pr.url}`)
+}

--- a/src/actions/addPackageJsonFunding.ts
+++ b/src/actions/addPackageJsonFunding.ts
@@ -26,25 +26,18 @@ const FUNDING_DEFAULT_FILE_CONTENT = defaultFundingPackageAsString
 /**
  * Finds last line before closing curly bracket of package.json
  * Adds comma
- * Adds newContent (new properties to package.json)
+ * Adds fundingUrl (new properties to package.json)
  * Add closing curly bracket
  * @param packageJSON
- * @param newContent
+ * @param fundingUrl
  */
-function updatePackageJson(packageJSON: String, newContent: String) {
-  const removeLastChar = packageJSON.substr(0, packageJSON.lastIndexOf('}'))
-  const indexes = [
-    removeLastChar.lastIndexOf('"'),
-    removeLastChar.lastIndexOf(']'),
-    removeLastChar.lastIndexOf('}'),
-  ]
-  const index = Math.max(...indexes)
-  return (
-    removeLastChar.substr(0, index + 1) +
-    `,
-  ${newContent}
-}`
-  )
+function updatePackageJson(packageJSON: string, fundingUrl: string) {
+  const obj = JSON.parse(packageJSON)
+  obj['funding'] = {
+    type: 'opencollective',
+    url: fundingUrl,
+  }
+  return JSON.stringify(obj, null, 2)
 }
 
 export default async function addPackageJsonFunding(
@@ -99,7 +92,7 @@ export default async function addPackageJsonFunding(
 
   await resetBranch(github, owner, repo, BRANCH_NAME, defaultBranchName)
 
-  // Add funding property to at the end of package.json that fetched from reposiory
+  // Add funding property to package.json that fetched from reposiory
   const updatedPackageJsonContent = updatePackageJson(
     packageJsonContent,
     fileContent,

--- a/src/actions/addPackageJsonFunding.ts
+++ b/src/actions/addPackageJsonFunding.ts
@@ -1,5 +1,6 @@
 import mls from 'multilines'
 import Octokit, { ReposGetResponse } from '@octokit/rest'
+import detectIndent from 'detect-indent'
 
 import { base64 } from '../utils'
 import { getCollectiveWithGithubHandle } from '../collective'
@@ -23,23 +24,21 @@ const PR_BODY = mls`
 
 const FUNDING_DEFAULT_FILE_CONTENT = defaultFundingPackageAsString
 
-/**
- * Finds last line before closing curly bracket of package.json
- * Adds comma
- * Adds fundingUrl (new properties to package.json)
- * Add closing curly bracket
- * @param packageJSON
- * @param fundingUrl
- */
+function setIndent(packageJSON: string): string {
+  return detectIndent(packageJSON).indent || '  '
+}
+
 function updatePackageJson(packageJSON: string, fundingUrl: string) {
+  const indent = setIndent(packageJSON)
   const obj = JSON.parse(packageJSON)
   obj['funding'] = {
     type: 'opencollective',
     url: fundingUrl,
   }
-  return JSON.stringify(obj, null, 2)
+  return JSON.stringify(obj, null, indent)
 }
 
+export { setIndent }
 export default async function addPackageJsonFunding(
   github: Octokit,
   repoResponse: ReposGetResponse,

--- a/src/actions/addPackageJsonFunding.ts
+++ b/src/actions/addPackageJsonFunding.ts
@@ -8,19 +8,20 @@ import { resetBranch } from '../github'
 
 const defaultFundingPackageAsString = `https://opencollective.com/<YOUR-COLLECTIVE-SLUG>`
 
-const BRANCH_NAME = `opencollective-bot/funding_package`
+const BRANCH_NAME = `opencollective-bot/package-json-funding`
 
 const FILE_PATH = 'package.json'
 
-const PR_TITLE = 'Add FUNDING to package.json'
+const PR_TITLE = 'Add "funding" property to package.json'
 
 const PR_BODY = mls`
-  | Add FUNDING to package.json
+  | Looks like you don't have yet the "funding" property added to your package.json.
   |
-  | Add FUNDING to package.json
+  | This property will be used by NPM to expose your project to developers running "npm fund".
   |
-  | Add FUNDING to package.json
-  `
+  | We recommend adding it!
+  |
+  | You can review and merge this PR to add the "funding" property to your package.json.`
 
 const FUNDING_DEFAULT_FILE_CONTENT = defaultFundingPackageAsString
 
@@ -57,7 +58,7 @@ export default async function addPackageJsonFunding(
     .catch(() => null)
 
   if (!packageJsonFile) {
-    console.log(`There is not package.json on ${owner}/${repo}`)
+    console.log(`There is no package.json on ${owner}/${repo}`)
     return
   }
 
@@ -69,7 +70,9 @@ export default async function addPackageJsonFunding(
 
   // Check if package.json already contains funding property
   if (packageJsonContent.includes('"funding":')) {
-    console.log(`Funding property already exists on ${owner}/${repo}`)
+    console.log(
+      `"funding" property already exists in package.json on ${owner}/${repo}`,
+    )
     return
   }
 
@@ -96,12 +99,13 @@ export default async function addPackageJsonFunding(
     packageJsonContent,
     fileContent,
   )
+
   // Update Package.json
   await github.repos.createOrUpdateFile({
     owner,
     repo,
     path: FILE_PATH,
-    message: `Funding added to ${FILE_PATH}`,
+    message: `chore: add "funding" property to ${FILE_PATH}`,
     content: base64(updatedPackageJsonContent),
     sha: packageJsonFile.sha,
     branch: BRANCH_NAME,
@@ -120,5 +124,5 @@ export default async function addPackageJsonFunding(
     })
     .then((res: any) => res.data)
 
-  console.log(`PR created for adding fund property to package.json: ${pr.url}`)
+  console.log(`PR created to add "funding" property to package.json: ${pr.url}`)
 }

--- a/src/actions/addPackageJsonFunding.ts
+++ b/src/actions/addPackageJsonFunding.ts
@@ -69,7 +69,7 @@ export default async function addPackageJsonFunding(
   ).toString()
 
   // Check if package.json already contains funding property
-  if (packageJsonContent.includes('"funding":')) {
+  if (JSON.parse(packageJsonContent)['funding']) {
     console.log(
       `"funding" property already exists in package.json on ${owner}/${repo}`,
     )

--- a/src/assets/default-funding-package.ts
+++ b/src/assets/default-funding-package.ts
@@ -1,0 +1,6 @@
+const defaultFundingPackage = `"funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/<YOUR-COLLECTIVE-SLUG>"
+  }`
+
+export default defaultFundingPackage

--- a/src/assets/default-funding-package.ts
+++ b/src/assets/default-funding-package.ts
@@ -1,3 +1,0 @@
-const defaultFundingPackage = `https://opencollective.com/<YOUR-COLLECTIVE-SLUG>`
-
-export default defaultFundingPackage

--- a/src/assets/default-funding-package.ts
+++ b/src/assets/default-funding-package.ts
@@ -1,6 +1,3 @@
-const defaultFundingPackage = `"funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/<YOUR-COLLECTIVE-SLUG>"
-  }`
+const defaultFundingPackage = `https://opencollective.com/<YOUR-COLLECTIVE-SLUG>`
 
 export default defaultFundingPackage

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -20,6 +20,7 @@ import { is, not } from './utils'
 
 import createConfiguration from './actions/createConfiguration'
 import createFunding from './actions/createFunding'
+import addPackageJsonFunding from './actions/addPackageJsonFunding'
 
 export const opencollective = (app: probot.Application): void => {
   app.log('Open Collective Bot up!')
@@ -45,6 +46,10 @@ export const opencollective = (app: probot.Application): void => {
 
       if (!process.env.FEATURE_DISABLE_FUNDING) {
         await createFunding(github, repo)
+      }
+
+      if (!process.env.FEATURE_DISABLE_FUNDING_PACKAGE_JSON) {
+        await addPackageJsonFunding(github, repo)
       }
     }
   })

--- a/tests/actions/addFundingToPackageJson.test.ts
+++ b/tests/actions/addFundingToPackageJson.test.ts
@@ -10,7 +10,7 @@ beforeEach(async () => {
   if (!nock.isActive()) nock.activate()
 
   process.env.FEATURE_DISABLE_CONFIGURATION = 'TRUE'
-  process.env.FEATURE_DISABLE_FUNDING_PACKAGE_JSON = 'TRUE'
+  process.env.FEATURE_DISABLE_FUNDING = 'TRUE'
 })
 
 afterEach(async () => {
@@ -18,11 +18,11 @@ afterEach(async () => {
   nock.cleanAll()
 
   delete process.env.FEATURE_DISABLE_CONFIGURATION
-  delete process.env.FEATURE_DISABLE_FUNDING_PACKAGE_JSON
+  delete process.env.FEATURE_DISABLE_FUNDING
 })
 
 describe('opencollective installation_repositories', () => {
-  test('properly create funding file if not exists and collective detected', async () => {
+  test('properly add funding property to the Package.Json if it exists and collective detected', async () => {
     nock('https://api.opencollective.com/')
       .post('/graphql/v2')
       .reply(200, {
@@ -41,144 +41,12 @@ describe('opencollective installation_repositories', () => {
           data: repository,
         }),
         getBranch: jest.fn().mockRejectedValue(new Error('Branch not found')),
-        getContents: jest.fn().mockImplementation(({ ref }) => {
-          if (!ref) {
-            return Promise.reject(new Error('File not found'))
-          } else {
-            return Promise.resolve({
-              data: {
-                content: 'YWJj',
-              },
-            })
-          }
-        }),
-        createOrUpdateFile: jest.fn(),
-      },
-      git: {
-        getRef: jest.fn().mockResolvedValue({
-          // we're just interested in sha
-          data: {
-            object: { sha: 'a9993e364706816aba3e25717850c26c9cd0d89d' },
-          },
-        }),
-        createRef: jest.fn(),
-        deleteRef: jest.fn(),
-      },
-      pulls: {
-        create: jest.fn().mockResolvedValue({
-          // we're just interested in url
-          data: { url: 'https://github.com/znarf/backyourstack/pull/11' },
-        }),
-      },
-    }
-
-    // Mock out GitHub client
-    app.load(opencollective)
-    app.auth = () => Promise.resolve(github as any)
-
-    await app.receive({
-      id: '123',
-      name: 'installation_repositories',
-      payload: installationRepositoriesFixture,
-    })
-
-    expect(github.repos.get).toBeCalledTimes(2)
-    expect(github.repos.getBranch).toBeCalledTimes(1)
-    expect(github.repos.getContents).toBeCalledTimes(2)
-    expect(github.repos.createOrUpdateFile).toBeCalledTimes(1)
-    expect(github.git.getRef).toBeCalledTimes(1)
-    expect(github.git.createRef).toBeCalledTimes(1)
-    expect(github.pulls.create).toBeCalledTimes(1)
-  })
-
-  test('properly create funding file if not exists and collective not detected', async () => {
-    nock('https://api.opencollective.com/')
-      .post('/graphql/v2')
-      .reply(200, {
-        data: {
-          collective: null,
-        },
-      })
-
-    const app = new probot.Application()
-
-    const github = {
-      repos: {
-        get: jest.fn().mockResolvedValue({
-          data: repository,
-        }),
-        getBranch: jest.fn().mockRejectedValue(new Error('Branch not found')),
-        getContents: jest.fn().mockImplementation(({ ref }) => {
-          if (!ref) {
-            return Promise.reject(new Error('File not found'))
-          } else {
-            return Promise.resolve({
-              data: {
-                content: 'YWJj',
-              },
-            })
-          }
-        }),
-        createOrUpdateFile: jest.fn(),
-      },
-      git: {
-        getRef: jest.fn().mockResolvedValue({
-          // we're just interested in sha
-          data: {
-            object: { sha: 'a9993e364706816aba3e25717850c26c9cd0d89d' },
-          },
-        }),
-        createRef: jest.fn(),
-        deleteRef: jest.fn(),
-      },
-      pulls: {
-        create: jest.fn().mockResolvedValue({
-          // we're just interested in url
-          data: { url: 'https://github.com/znarf/backyourstack/pull/11' },
-        }),
-      },
-    }
-
-    // Mock out GitHub client
-    app.load(opencollective)
-    app.auth = () => Promise.resolve(github as any)
-
-    await app.receive({
-      id: '123',
-      name: 'installation_repositories',
-      payload: installationRepositoriesFixture,
-    })
-
-    expect(github.repos.get).toBeCalledTimes(2)
-    expect(github.repos.getBranch).toBeCalledTimes(1)
-    expect(github.repos.getContents).toBeCalledTimes(2)
-    expect(github.repos.createOrUpdateFile).toBeCalledTimes(1)
-    expect(github.git.getRef).toBeCalledTimes(1)
-    expect(github.git.createRef).toBeCalledTimes(1)
-    expect(github.pulls.create).toBeCalledTimes(1)
-  })
-
-  test('do nothing if funding.yml exists', async () => {
-    nock('https://api.opencollective.com/')
-      .post('/graphql/v2')
-      .reply(200, {
-        data: {
-          collective: null,
-        },
-      })
-
-    const app = new probot.Application()
-
-    const github = {
-      repos: {
-        get: jest.fn().mockResolvedValue({
-          data: repository,
-        }),
-        getBranch: jest.fn().mockRejectedValue(new Error('Branch not found')),
         getContents: jest.fn().mockImplementation(() => {
           return Promise.resolve({
             data: {
-              content: 'YWJj',
+              name: 'package.json',
+              path: 'package.json',
+              content: `{"name": "backyourstack"}`,
             },
           })
         }),
@@ -212,7 +80,223 @@ describe('opencollective installation_repositories', () => {
       payload: installationRepositoriesFixture,
     })
 
-    expect(github.repos.getContents).toBeCalledTimes(2)
+    expect(github.repos.get).toBeCalledTimes(2)
+    expect(github.repos.getBranch).toBeCalledTimes(1)
+    expect(github.repos.getContents).toBeCalledTimes(1)
+    expect(github.repos.createOrUpdateFile).toBeCalledTimes(1)
+    expect(github.git.getRef).toBeCalledTimes(1)
+    expect(github.git.createRef).toBeCalledTimes(1)
+    expect(github.pulls.create).toBeCalledTimes(1)
+  })
+
+  test('properly add funding property to the Package.Json if it exists and collective not detected', async () => {
+    nock('https://api.opencollective.com/')
+      .post('/graphql/v2')
+      .reply(200, {
+        data: {
+          collective: null,
+        },
+      })
+
+    const app = new probot.Application()
+
+    const github = {
+      repos: {
+        get: jest.fn().mockResolvedValue({
+          data: repository,
+        }),
+        getBranch: jest.fn().mockRejectedValue(new Error('Branch not found')),
+        getContents: jest.fn().mockImplementation(() => {
+          return Promise.resolve({
+            data: {
+              name: 'package.json',
+              path: 'package.json',
+              content: `{"name": "backyourstack"}`,
+            },
+          })
+        }),
+        createOrUpdateFile: jest.fn(),
+      },
+      git: {
+        getRef: jest.fn().mockResolvedValue({
+          // we're just interested in sha
+          data: {
+            object: { sha: 'a9993e364706816aba3e25717850c26c9cd0d89d' },
+          },
+        }),
+        createRef: jest.fn(),
+        deleteRef: jest.fn(),
+      },
+      pulls: {
+        create: jest.fn().mockResolvedValue({
+          // we're just interested in url
+          data: { url: 'https://github.com/znarf/backyourstack/pull/11' },
+        }),
+      },
+    }
+
+    // Mock out GitHub client
+    app.load(opencollective)
+    app.auth = () => Promise.resolve(github as any)
+
+    await app.receive({
+      id: '123',
+      name: 'installation_repositories',
+      payload: installationRepositoriesFixture,
+    })
+
+    expect(github.repos.get).toBeCalledTimes(2)
+    expect(github.repos.getBranch).toBeCalledTimes(1)
+    expect(github.repos.getContents).toBeCalledTimes(1)
+    expect(github.repos.createOrUpdateFile).toBeCalledTimes(1)
+    expect(github.git.getRef).toBeCalledTimes(1)
+    expect(github.git.createRef).toBeCalledTimes(1)
+    expect(github.pulls.create).toBeCalledTimes(1)
+  })
+
+  test('do nothing, if package.json does not exist', async () => {
+    nock('https://api.opencollective.com/')
+      .post('/graphql/v2')
+      .reply(200, {
+        data: {
+          collective: {
+            slug: 'backyourstack',
+          },
+        },
+      })
+
+    const app = new probot.Application()
+
+    const github = {
+      repos: {
+        get: jest.fn().mockResolvedValue({
+          data: repository,
+        }),
+        getBranch: jest.fn().mockRejectedValue(new Error('Branch not found')),
+        getContents: jest.fn().mockImplementation(({ ref }) => {
+          if (!ref) {
+            return Promise.reject(new Error('File not found'))
+          } else {
+            return Promise.resolve({
+              data: {
+                name: 'package.json',
+                path: 'package.json',
+                content: `{"name": "backyourstack"}`,
+              },
+            })
+          }
+        }),
+        createOrUpdateFile: jest.fn(),
+      },
+      git: {
+        getRef: jest.fn().mockResolvedValue({
+          // we're just interested in sha
+          data: {
+            object: { sha: 'a9993e364706816aba3e25717850c26c9cd0d89d' },
+          },
+        }),
+        createRef: jest.fn(),
+        deleteRef: jest.fn(),
+      },
+      pulls: {
+        create: jest.fn().mockResolvedValue({
+          // we're just interested in url
+          data: { url: 'https://github.com/znarf/backyourstack/pull/11' },
+        }),
+      },
+    }
+
+    // Mock out GitHub client
+    app.load(opencollective)
+    app.auth = () => Promise.resolve(github as any)
+
+    await app.receive({
+      id: '123',
+      name: 'installation_repositories',
+      payload: installationRepositoriesFixture,
+    })
+
+    expect(github.repos.getContents).toBeCalledTimes(1)
+    expect(github.repos.get).toBeCalledTimes(1)
+    expect(github.repos.getBranch).toBeCalledTimes(0)
+    expect(github.git.deleteRef).toBeCalledTimes(0)
+    expect(github.git.getRef).toBeCalledTimes(0)
+    expect(github.git.createRef).toBeCalledTimes(0)
+    expect(github.repos.createOrUpdateFile).toBeCalledTimes(0)
+    expect(github.pulls.create).toBeCalledTimes(0)
+  })
+
+  test('do nothing, if package.json contains already funding property', async () => {
+    nock('https://api.opencollective.com/')
+      .post('/graphql/v2')
+      .reply(200, {
+        data: {
+          collective: {
+            slug: 'backyourstack',
+          },
+        },
+      })
+
+    const app = new probot.Application()
+
+    const github = {
+      repos: {
+        get: jest.fn().mockResolvedValue({
+          data: repository,
+        }),
+        getBranch: jest.fn().mockRejectedValue(new Error('Branch not found')),
+        getContents: jest.fn().mockImplementation(() => {
+          return Promise.resolve({
+            data: {
+              name: 'package.json',
+              path: 'package.json',
+              /*  
+                    content: 
+                    {
+                        "name": "backyourstack",
+                        "version": "1.1.0",
+                        "funding": {
+                            "type": "opencollective",
+                            "url": "https://opencollective.com/backyourstack"
+                        }
+                    }
+                    */
+              content:
+                'ewogICJuYW1lIjogImJhY2t5b3Vyc3RhY2siLAogICJ2ZXJzaW9uIjogIjEu\nMS4wIiwKICAiZnVuZGluZyI6IHsKICAgICJ0eXBlIjogIm9wZW5jb2xsZWN0\naXZlIiwKICAgICJ1cmwiOiAiaHR0cHM6Ly9vcGVuY29sbGVjdGl2ZS5jb20v\nYmFja3lvdXJzdGFjayIKICB9Cn0K\n',
+            },
+          })
+        }),
+        createOrUpdateFile: jest.fn(),
+      },
+      git: {
+        getRef: jest.fn().mockResolvedValue({
+          // we're just interested in sha
+          data: {
+            object: { sha: 'a9993e364706816aba3e25717850c26c9cd0d89d' },
+          },
+        }),
+        createRef: jest.fn(),
+        deleteRef: jest.fn(),
+      },
+      pulls: {
+        create: jest.fn().mockResolvedValue({
+          // we're just interested in url
+          data: { url: 'https://github.com/znarf/backyourstack/pull/11' },
+        }),
+      },
+    }
+
+    // Mock out GitHub client
+    app.load(opencollective)
+    app.auth = () => Promise.resolve(github as any)
+
+    await app.receive({
+      id: '123',
+      name: 'installation_repositories',
+      payload: installationRepositoriesFixture,
+    })
+
+    expect(github.repos.getContents).toBeCalledTimes(1)
     expect(github.repos.get).toBeCalledTimes(1)
     expect(github.repos.getBranch).toBeCalledTimes(0)
     expect(github.git.deleteRef).toBeCalledTimes(0)

--- a/tests/actions/addFundingToPackageJson.test.ts
+++ b/tests/actions/addFundingToPackageJson.test.ts
@@ -5,6 +5,7 @@ import { opencollective } from '../../src/bot'
 
 import installationRepositoriesFixture from '../__fixtures__/installation_repositories.added'
 import repository from '../__fixtures__/repos.get-1'
+import { setIndent } from '../../src/actions/addPackageJsonFunding'
 
 beforeEach(async () => {
   if (!nock.isActive()) nock.activate()
@@ -337,5 +338,37 @@ describe('opencollective installation_repositories', () => {
     expect(github.git.createRef).toBeCalledTimes(0)
     expect(github.repos.createOrUpdateFile).toBeCalledTimes(0)
     expect(github.pulls.create).toBeCalledTimes(0)
+  })
+})
+
+describe('package.json indents', () => {
+  test('mixed, gets first line indents (8)', () => {
+    expect(
+      setIndent(`
+      {
+              "name": "backyourstack",
+        "version": "1.1.0",
+            "jest": {
+          "coverageDirectory": "./coverage/",
+      "collectCoverage": true
+              }
+      }
+      `),
+    ).toBe('        ')
+  })
+
+  test('no indent, sets (2)', () => {
+    expect(
+      setIndent(
+        `{
+"name": "backyourstack",
+"version": "1.1.0",
+"jest": {
+"coverageDirectory": "./coverage/",
+"collectCoverage": true
+}
+}`,
+      ),
+    ).toBe('  ')
   })
 })

--- a/tests/actions/addFundingToPackageJson.test.ts
+++ b/tests/actions/addFundingToPackageJson.test.ts
@@ -46,7 +46,18 @@ describe('opencollective installation_repositories', () => {
             data: {
               name: 'package.json',
               path: 'package.json',
-              content: `{"name": "backyourstack"}`,
+              /* 
+                content: {
+                  "name": "backyourstack",
+                  "version": "1.1.0",
+                  "jest": {
+                    "coverageDirectory": "./coverage/",
+                    "collectCoverage": true
+                  }
+                }
+              */
+              content:
+                'ewogICJuYW1lIjogImJhY2t5b3Vyc3RhY2siLAogICJ2ZXJzaW9uIjogIjEu\nMS4wIiwKICAiamVzdCI6IHsKICAgICJjb3ZlcmFnZURpcmVjdG9yeSI6ICIu\nL2NvdmVyYWdlLyIsCiAgICAiY29sbGVjdENvdmVyYWdlIjogdHJ1ZQogIH0K\nfQo=\n',
             },
           })
         }),
@@ -111,7 +122,18 @@ describe('opencollective installation_repositories', () => {
             data: {
               name: 'package.json',
               path: 'package.json',
-              content: `{"name": "backyourstack"}`,
+              /* 
+                  content: {
+                    "name": "backyourstack",
+                    "version": "1.1.0",
+                    "jest": {
+                      "coverageDirectory": "./coverage/",
+                      "collectCoverage": true
+                    }
+                  }
+                */
+              content:
+                'ewogICJuYW1lIjogImJhY2t5b3Vyc3RhY2siLAogICJ2ZXJzaW9uIjogIjEu\nMS4wIiwKICAiamVzdCI6IHsKICAgICJjb3ZlcmFnZURpcmVjdG9yeSI6ICIu\nL2NvdmVyYWdlLyIsCiAgICAiY29sbGVjdENvdmVyYWdlIjogdHJ1ZQogIH0K\nfQo=\n',
             },
           })
         }),
@@ -181,7 +203,18 @@ describe('opencollective installation_repositories', () => {
               data: {
                 name: 'package.json',
                 path: 'package.json',
-                content: `{"name": "backyourstack"}`,
+                /* 
+                  content: {
+                    "name": "backyourstack",
+                    "version": "1.1.0",
+                    "jest": {
+                      "coverageDirectory": "./coverage/",
+                      "collectCoverage": true
+                    }
+                  }
+                */
+                content:
+                  'ewogICJuYW1lIjogImJhY2t5b3Vyc3RhY2siLAogICJ2ZXJzaW9uIjogIjEu\nMS4wIiwKICAiamVzdCI6IHsKICAgICJjb3ZlcmFnZURpcmVjdG9yeSI6ICIu\nL2NvdmVyYWdlLyIsCiAgICAiY29sbGVjdENvdmVyYWdlIjogdHJ1ZQogIH0K\nfQo=\n',
               },
             })
           }

--- a/tests/actions/createConfiguration.test.ts
+++ b/tests/actions/createConfiguration.test.ts
@@ -14,6 +14,7 @@ beforeEach(async () => {
   if (!nock.isActive()) nock.activate()
 
   process.env.FEATURE_DISABLE_FUNDING = 'TRUE'
+  process.env.FEATURE_DISABLE_FUNDING_PACKAGE_JSON = 'TRUE'
 })
 
 afterEach(async () => {
@@ -21,6 +22,7 @@ afterEach(async () => {
   nock.cleanAll()
 
   delete process.env.FEATURE_DISABLE_FUNDING
+  delete process.env.FEATURE_DISABLE_FUNDING_PACKAGE_JSON
 })
 
 describe('opencollective installation_repositories', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,6 +1665,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+detect-indent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
+  integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"


### PR DESCRIPTION
**Issue:** https://github.com/opencollective/opencollective/issues/2604

Please update **PR_TITLE** and **PR_BODY**. I just put some placeholder strings for these two.

Basically I am checking 

- whether there is a package.json or not in the repo. 

I guess you were talking about whether package.json exists or not in the sentence below. 
(I thought, maybe it would be funding.yml but I guess not)

>  we would like now to add "funding" to package.json if **it** exists

- Also checking whether package.json has already funding property or not

If there is a package.json without funding property, code runs and add this at the bottom of package.json

```
"funding": {
    "type": "opencollective",
    "url": "https://opencollective.com/<YOUR-COLLECTIVE-SLUG>"
  }
```

These are screenshots from auto generated PR
![Screenshot from 2019-11-10 22-40-56](https://user-images.githubusercontent.com/38403291/68549827-92ab3080-040d-11ea-9426-ed7a6b89be02.png)
![Screenshot from 2019-11-10 22-41-02](https://user-images.githubusercontent.com/38403291/68549828-92ab3080-040d-11ea-9b3b-a5e46e441484.png)

