### PR TITLE
more explanatory YAML error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 dist
 coverage
 .vscode
+.history
 
 .DS_Store
 *.log*

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -43,6 +43,12 @@ validator.post(
         return res.status(400).send(message)
       }
 
+      if (err.name === 'YAMLException') {
+        const message =
+          'YAML file is not properly formatted:\nSyntaxError: ' + err.message
+        return res.status(400).send(message)
+      }
+
       return res.status(400).send('Something went wrong.')
     }
   },

--- a/tests/__snapshots__/validate.test.ts.snap
+++ b/tests/__snapshots__/validate.test.ts.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`validate correctly handles invalid input 1`] = `[StatusCodeError: 400 - "Something went wrong."]`;
-
 exports[`validate correctly reports invalid configuration 1`] = `[StatusCodeError: 400 - "- collective: \\"collective\\" is required\\n- opencollective: \\"opencollective\\" is not allowed"]`;
 
 exports[`validate correctly validates valid configuration 1`] = `"Valid configuration!"`;

--- a/tests/__snapshots__/validate.test.ts.snap
+++ b/tests/__snapshots__/validate.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`validate correctly handles unexpected errors 1`] = `[StatusCodeError: 400 - "Something went wrong."]`;
+
 exports[`validate correctly reports invalid configuration 1`] = `[StatusCodeError: 400 - "- collective: \\"collective\\" is required\\n- opencollective: \\"opencollective\\" is not allowed"]`;
 
 exports[`validate correctly validates valid configuration 1`] = `"Valid configuration!"`;

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -52,7 +52,7 @@ describe('validate', () => {
       })
   })
 
-  test('correctly handles invalid input', async () => {
+  test('correctly handles invalid input, YAMLException', async () => {
     const config = `f123
       opencollective: 'https://opencollective.com/graphql-shield',
     `
@@ -70,7 +70,8 @@ describe('validate', () => {
         fail()
       })
       .catch(err => {
-        expect(err).toMatchSnapshot()
+        console.log(err.message)
+        expect(err.message).toContain('YAML file is not properly formatted')
       })
   })
 

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,4 +1,4 @@
-import { safeDump } from 'js-yaml'
+import JSYAML from 'js-yaml'
 import express from 'express'
 import request from 'request-promise-native'
 
@@ -31,7 +31,7 @@ describe('validate', () => {
   })
 
   test('correctly reports invalid configuration', async () => {
-    const config = safeDump({
+    const config = JSYAML.safeDump({
       opencollective: 'https://opencollective.com/graphql-shield',
     })
 
@@ -75,8 +75,34 @@ describe('validate', () => {
       })
   })
 
+  test('correctly handles unexpected errors', async () => {
+    const baseSafeLoad = JSYAML.safeLoad
+
+    // mock safe load
+    JSYAML.safeLoad = () => {
+      throw new Error('Test')
+    }
+
+    try {
+      await expect(
+        request({
+          uri,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: JSYAML.safeDump({
+            collective: 'graphql-shield',
+          }),
+        }),
+      ).rejects.toMatchSnapshot()
+    } finally {
+      JSYAML.safeLoad = baseSafeLoad
+    }
+  })
+
   test('correctly validates valid configuration', async () => {
-    const config = safeDump({
+    const config = JSYAML.safeDump({
       collective: 'graphql-shield',
     })
 


### PR DESCRIPTION
**Issue:** https://github.com/opencollective/opencollective/issues/2613

**Command:**
`curl -X POST --data-binary @.github/opencollectttp://localhost:3000/validate`

**Response:**
```
YAML file is not properly formatted:
SyntaxError: bad indentation of a mapping entry at line 65, column 5:
        labels: ['priority']
```

**TODO:** We need to change test response, could you please give me a hint how we should do that ? 
I thought we might think use if the response string contains **YAML file is not properly formatted: SyntaxError: **, it passes but need your opinion. 
Also YAML error message might be different according to error for sure. I am not specifically looking for any indentation errors. 
Such as: 

- end of the stream or a document separator is expected at line 2, column 21:
- bad indentation of a mapping entry at line 65, column 5: