### PR TITLE
Remove dependabot.yml so that we could migrate to v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: Europe/Berlin


### PR DESCRIPTION
Removes `dependabot.yml` so that we can use dependabot-preview instead.